### PR TITLE
Update documentation to match project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -133,9 +133,8 @@ asciidoctor {
         idprefix: '',  // for compatibility with GitHub preview
         idseparator: '-',
         'site-root': "${sourceDir}",  // must be the same as sourceDir, do not modify
-        'site-name': 'AddressBook-Level3',
-        'site-githuburl': 'https://github.com/se-edu/addressbook-level3',
-        'site-seedu': true,  // delete this line if your project is not a fork (not a SE-EDU project)
+        'site-name': 'Modulo',
+        'site-githuburl': 'https://github.com/AY1920S1-CS2103-T16-2/main',
     ]
 
     options['template_dirs'].each {


### PR DESCRIPTION
As per [Developer Guide](https://github.com/tohcejasmine/main/blob/master/docs/SettingUp.adoc#42-updating-documentation-to-match-your-fork) from AB3, update name of website and URL to reference _Modulo_ instead of AB3, also removes SE-EDU navigation bar at the top of documentation websites.